### PR TITLE
Added support for unloading of generated assemblies in .NET Core

### DIFF
--- a/Samples/SampleProjects/LoadContext/LoadContext.csproj
+++ b/Samples/SampleProjects/LoadContext/LoadContext.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <RootNamespace>LoadContext</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\SharpDocx\SharpDocx.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/SampleProjects/LoadContext/Program.cs
+++ b/Samples/SampleProjects/LoadContext/Program.cs
@@ -39,7 +39,8 @@ namespace LoadContext
             Console.WriteLine(string.Join(Environment.NewLine, assemblyNames));
 
             LoadContext.Unload();
-            
+            DocumentFactory.LoadContext = null;
+
             Console.WriteLine("Document Assemblies have been unloaded.");
         }
 

--- a/Samples/SampleProjects/LoadContext/Program.cs
+++ b/Samples/SampleProjects/LoadContext/Program.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using SharpDocx;
+
+namespace LoadContext
+{
+    internal class Program
+    {
+        private static readonly string BasePath =
+            Path.GetDirectoryName(typeof(Program).Assembly.Location) + @"/../../../../..";
+
+        static AssemblyLoadContext LoadContext = new TestAssemblyLoadContext(Path.GetDirectoryName(typeof(Program).Assembly.Location));
+
+        private static void Main()
+        {
+            DocumentFactory.LoadContext = LoadContext;
+
+            var viewPath = $"{BasePath}/Views/Tutorial.cs.docx";
+            var documentPath = $"{BasePath}/Documents/Tutorial.docx";
+            var imageDirectory = $"{BasePath}/Images";
+
+#if DEBUG
+            Ide.Start(viewPath, documentPath, null, null, f => f.ImageDirectory = imageDirectory);
+
+#else
+            DocumentBase document = DocumentFactory.Create(viewPath);
+            document.ImageDirectory = imageDirectory;
+            document.Generate(documentPath);
+#endif
+            Console.WriteLine("---------------------Assemblies Loaded In the Default Context-------------------------------");
+            var assemblyNames = AssemblyLoadContext.Default.Assemblies.Select(s => s.FullName).ToArray();
+            Console.WriteLine(string.Join(Environment.NewLine, assemblyNames));
+
+            Console.WriteLine("---------------------Assemblies Loaded In Context-------------------------------");
+             assemblyNames = LoadContext.Assemblies.Select(s => s.FullName).ToArray();
+            Console.WriteLine(string.Join(Environment.NewLine, assemblyNames));
+
+            LoadContext.Unload();
+            
+            Console.WriteLine("Document Assemblies have been unloaded.");
+        }
+
+        class TestAssemblyLoadContext : AssemblyLoadContext
+        {
+            private readonly AssemblyDependencyResolver _resolver;
+
+            public TestAssemblyLoadContext(string mainAssemblyToLoadPath) : base(isCollectible: true)
+            {
+                _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+            }
+
+            protected override Assembly Load(AssemblyName name)
+            {
+                string assemblyPath = _resolver.ResolveAssemblyToPath(name);
+                if (assemblyPath != null)
+                {
+                    return LoadFromAssemblyPath(assemblyPath);
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/Samples/SampleProjects/LoadContext/TestAssemblyLoadContext.cs
+++ b/Samples/SampleProjects/LoadContext/TestAssemblyLoadContext.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace LoadContext
+{
+    internal class TestAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver _resolver;
+
+        public TestAssemblyLoadContext(string mainAssemblyToLoadPath) : base(isCollectible: true)
+        {
+            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+        }
+
+        protected override Assembly Load(AssemblyName name)
+        {
+            string assemblyPath = _resolver.ResolveAssemblyToPath(name);
+            if (assemblyPath != null)
+            {
+                return LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        }
+    }
+}

--- a/SharpDocx.sln
+++ b/SharpDocx.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpDocx", "SharpDocx\SharpDocx.csproj", "{11025F4C-5F88-4CBF-A29D-494260BF71F8}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documents", "Documents", "{
 		Samples\Documents\Tutorial.docx = Samples\Documents\Tutorial.docx
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoadContext", "Samples\SampleProjects\LoadContext\LoadContext.csproj", "{9D7245CD-AFC0-4324-A21B-FAB87BC3A5F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,6 +60,10 @@ Global
 		{469F76BC-D622-4AB7-B71E-DA7F265E7E05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{469F76BC-D622-4AB7-B71E-DA7F265E7E05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{469F76BC-D622-4AB7-B71E-DA7F265E7E05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D7245CD-AFC0-4324-A21B-FAB87BC3A5F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D7245CD-AFC0-4324-A21B-FAB87BC3A5F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D7245CD-AFC0-4324-A21B-FAB87BC3A5F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D7245CD-AFC0-4324-A21B-FAB87BC3A5F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -68,6 +74,7 @@ Global
 		{3D8D60E1-5B3B-47B7-97E5-996F8906DF76} = {60ACA8F2-9057-4F58-ABF4-0278D2968EEA}
 		{28BE5D1E-9170-44D4-89C4-A0C8086021CC} = {60ACA8F2-9057-4F58-ABF4-0278D2968EEA}
 		{985BA596-7B45-4F2B-9A9E-A712408AF9D8} = {60ACA8F2-9057-4F58-ABF4-0278D2968EEA}
+		{9D7245CD-AFC0-4324-A21B-FAB87BC3A5F8} = {60ACA8F2-9057-4F58-ABF4-0278D2968EEA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F682D28B-E23F-4280-9FE6-AB5ABFDCB3F2}

--- a/SharpDocx/DocumentCompiler.cs
+++ b/SharpDocx/DocumentCompiler.cs
@@ -383,7 +383,8 @@ namespace {Namespace}
                 }
 
                 ms.Seek(0, SeekOrigin.Begin);
-                return Assembly.Load(ms.ToArray());
+
+                return DocumentFactory.LoadContext != null ? DocumentFactory.LoadContext.LoadFromStream(ms) : Assembly.Load(ms.ToArray());
             }
 #endif
         }

--- a/SharpDocx/DocumentFactory.cs
+++ b/SharpDocx/DocumentFactory.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.IO;
+#if NETSTANDARD2_0
+using System.Runtime.Loader;
+#endif
 
 namespace SharpDocx
 {
@@ -13,10 +16,67 @@ namespace SharpDocx
         private static readonly Hashtable Assemblies = new Hashtable();
         private static readonly object AssembliesLock = new object();
 
+#if NETSTANDARD2_0
+
+        private static readonly object LoadContextLock = new object();
+        private static AssemblyLoadContext _loadContext;
+
+        /// <summary>
+        /// Sets the load context for the generated assemblies. Setting this context or calling <see cref="AssemblyLoadContext"/> will clear assembly cache.
+        /// <para></para>
+        /// </summary>
+        public static AssemblyLoadContext LoadContext
+        {
+            get
+            {
+                lock (LoadContextLock)
+                {
+                    return _loadContext;
+                }
+            }
+            set
+            {
+                lock (LoadContextLock)
+                {
+                    //if replacing load context clear assemblies
+                    if (_loadContext != null && _loadContext != value)
+                    {
+                        lock (AssembliesLock)
+                        {
+                            Assemblies.Clear();
+                        }
+
+                        _loadContext.Unloading -= LoadContextOnUnloading;
+                    }
+
+                    _loadContext = value;
+
+                    if (_loadContext != null)
+                    {
+                        //any call to unload should clear assemblies as the load context will be unusable
+                        _loadContext.Unloading += LoadContextOnUnloading;
+                    }
+                }
+            }
+        }
+
+        private static void LoadContextOnUnloading(AssemblyLoadContext obj)
+        {
+            lock (LoadContextLock)
+            {
+                lock (AssembliesLock)
+                {
+                    Assemblies.Clear();
+                }
+            }
+        }
+
+#endif
+
         public static TBaseClass Create<TBaseClass>(string viewPath, object model = null, bool forceCompile = false)
             where TBaseClass : DocumentBase
         {
-            return (TBaseClass) Create(viewPath, model, typeof(TBaseClass), forceCompile);
+            return (TBaseClass)Create(viewPath, model, typeof(TBaseClass), forceCompile);
         }
 
         public static DocumentBase Create(
@@ -38,7 +98,7 @@ namespace SharpDocx
 
             lock (AssembliesLock)
             {
-                da = (DocumentAssembly) Assemblies[viewPath + baseClassName + modelTypeName];
+                da = (DocumentAssembly)Assemblies[viewPath + baseClassName + modelTypeName];
 
                 if (da == null || forceCompile)
                 {
@@ -51,7 +111,7 @@ namespace SharpDocx
                 }
             }
 
-            var document = (DocumentBase) da.Instance();
+            var document = (DocumentBase)da.Instance();
             document.Init(viewPath, model);
             return document;
         }

--- a/SharpDocx/SharpDocx.csproj
+++ b/SharpDocx/SharpDocx.csproj
@@ -38,6 +38,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>2.10.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Runtime.Loader">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <ProjectReference Include="..\SharpImage\SharpImage.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The current implementation did not support unloading of assemblies in .NET Core. This PR adds functionality to the netstandard2.0 compilation target to allow an assembly load context property to be optionally set for the factory. When set, the generated assemblies get loaded into this context which if using netcoreapp3.0 or above can be unloaded if needed.

This functionality is completely optional and should be non breaking. Looking forward to your feeback and getting this merged into the project. Thanks.