### PR TITLE
Fix "baseClass should be a DocumentBase derived type" error, when SharpDocx has been loaded in an AssemblyLoadConterxt

### DIFF
--- a/SharpDocx/DocumentAssembly.cs
+++ b/SharpDocx/DocumentAssembly.cs
@@ -39,8 +39,8 @@ namespace SharpDocx
                 throw new ArgumentNullException(nameof(baseClass));
             }
 
-            // Load base class assembly.
-            var a = Assembly.LoadFrom(baseClass.Assembly.Location);
+            // Get the base class assembly.
+            var a = baseClass.Assembly;
             if (a == null)
             {
                 throw new ArgumentException($"Can't load assembly '{baseClass.Assembly}'", nameof(baseClass));


### PR DESCRIPTION
Hi,

We have an application that uses it's own `AssemblyLoadContext` to load "plugins" and their dependencies in an isolated context. When we authored a plugin that uses SharpDocx we ran into a problem resulting in this error: `"baseClass should be a DocumentBase derived type"`

We are already passing our custom `AssemblyLoadContext` to the provided property on `DocumentFactory` but there is an earlier check here https://github.com/egonl/SharpDocx/blob/96d0b9c4700e0e3824a22c5a95e06edf6659c592/SharpDocx/DocumentAssembly.cs#L59 that fails to recognise the provided `DocumentBase` as a `DocumentBase` or `IsSubclassOf(DocumentBase)` - because the one type has come from our ALC whilst the other one has been loaded into a new context (or the default context i guess?) by the `Assembly.LoadFrom()` call earlier.

Since the `baseClass` type has already been passed in, there doesn't seem a need to explicitly load its assembly using `Assembly.LoadFrom(baseClass.Assembly.Location)` - Instead, simply using `baseType.Assembly` appears to be all that is required to get the "correct" types/assemblies from the correct instance, and have the subsequent type checks work as intended.

Then, importantly, the actual generated code and Roslyn compilation etc performed by the library works fine, using the ALC that was already passed/set on the `DocumentFactory`.

So it seems this simple tweak is all that was required to have SharpDocx work in this use case (as well as a more direct/traditional one, not using any custom AssemblyLoadContext).


Let me know if you want to accept this contribution, or if any tests should be added/updated.

Thanks, for a great library!